### PR TITLE
fix naive-navigate to use position of destination

### DIFF
--- a/starter_kits/Clojure/hlt/lib/hlt/game_map.clj
+++ b/starter_kits/Clojure/hlt/lib/hlt/game_map.clj
@@ -101,7 +101,8 @@
   still if no such move exists."
   [ship destination]
   (let [ship-position (:position ship)
-        unsafe-moves (get-unsafe-moves ship-position destination)
+        destination-position (:position destination)
+        unsafe-moves (get-unsafe-moves ship-position destination-position)
         dir (reduce
               (fn [_ direction]
                 (if (is-empty?

--- a/starter_kits/Clojure/project.clj
+++ b/starter_kits/Clojure/project.clj
@@ -3,6 +3,7 @@
                  [com.taoensso/timbre "4.10.0"]
                  [org.clojure/data.json "0.2.6"]]
   :source-paths ["hlt/lib" "hlt/app"]
+  :test-paths ["test"]
   :main MyBot
   :aot [MyBot]
   :uberjar-name "MyBot.jar")

--- a/starter_kits/Clojure/test/hlt/game_map_test.clj
+++ b/starter_kits/Clojure/test/hlt/game_map_test.clj
@@ -1,0 +1,16 @@
+(ns hlt.game-map-test
+  (:require [clojure.test :refer :all]
+            [hlt.ship :as ship]
+            [hlt.player :as player]
+            [hlt.shipyard :as shipyard]
+            [hlt.game-map :refer :all]))
+
+(deftest test-naive-navigate
+  (with-redefs [game-map  (fn [] {:width 32  :height 32})
+                ]
+  (let [ship {::ship/id 1 ::player/id 0 :position [8 10] :halite 100}
+        shipyard {::shipyard/id -1  ::player/id 0 :position [8 16]}
+        
+        ]
+    (is (= [0 1] (naive-navigate ship shipyard)))
+    )))


### PR DESCRIPTION
change the naive-navigate to pass the position of the destination to
get-unsafe-moves rather than the destination object